### PR TITLE
Added support for multiline-docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,10 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# Vim
+vim/
+.vim/
+
 # IPython
 profile_default/
 ipython_config.py

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,3 @@
+{
+  "python.formatting.provider": "black"
+}

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,3 +1,0 @@
-{
-  "python.formatting.provider": "black"
-}

--- a/ex/car.py
+++ b/ex/car.py
@@ -1,14 +1,30 @@
-
 class car:
     def __init__(self):
         self.wheels = 0
         self.doors = 0
-        self.engien = ""
+        self.engine = ""
         self.number_plate = ""
 
-    def start():
-        """ starts the engien of the car """
-        pass
+    def start(self):
+        """starts the engine of the car"""
+        self.engine = """Running"""
+
+    def stop(self):
+        """Stop the engine of the car!"""
+        self.engine = "Stopping"
+
+    def honk(self):
+        """
+        Use
+        "The"
+        ""Horn""
+        """
+        print("Honking...")
+        print("Honk Honk!")
 
     def __str__(self):
+        """
+        example of a longer multiline-docstring,
+        everything will be printed on a single line
+        """
         return self.number_plate

--- a/inkpot/filter.py
+++ b/inkpot/filter.py
@@ -1,23 +1,46 @@
-
 def filter_file(file_path):
-    """ find the function and docstrings in the file """
+    """find the function and docstrings in the file"""
     flag = False
     last_func = ""
+
+    doc_token = '"""'
+    doc_open = None
+    doc_close = None
+    doc = ""
+
     table = {}
-    with open(file_path, 'r') as file:
+    with open(file_path, "r") as file:
         for cnt, line in enumerate(file):
-            #print("Line {}: {}".format(cnt, line))
+            # print("Line {}: {}".format(cnt, line))
             if "def" in line:
-                func = line.replace("def ", '')
-                func = func.replace('\n', '')
-                func = func.replace(':', '')
+                func = line.replace("def ", "")
+                func = func.replace("\n", "")
+                func = func.replace(":", "")
                 table[func] = ""
                 last_func = func
                 flag = True
             elif flag:
-                doc = line.replace('\n', '')
-                doc = doc.replace('  ', '')
-                doc = doc.replace('"""', '')
-                table[last_func] = doc
-                flag = False
+                if not doc_open:
+                    doc_open = (line.strip().find(doc_token), cnt)
+                    # No docstring found
+                    if doc_open[0] != 0:
+                        table[func] = "no docstring"
+                        doc_open = None
+                        flag = False
+                        continue
+
+                if not doc_close:
+                    doc_close = (line.strip().rfind(doc_token), cnt)
+                    if doc_close == doc_open or doc_close[0] == -1:
+                        doc_close = None
+
+                doc += line.strip() + " "
+
+                if doc_open and doc_close:
+                    table[last_func] = doc.strip().strip(doc_token).strip().lower()
+                    doc_open = None
+                    doc_close = None
+                    doc = ""
+                    flag = False
+
     return table


### PR DESCRIPTION
# Previously, only singleline-docstrings were supported, but not longer.
## Test Car Class:
```python
class car:
    def __init__(self):
        self.wheels = 0
        self.doors = 0
        self.engine = ""
        self.number_plate = ""

    def start(self):
        """starts the engine of the car"""
        self.engine = """Running"""

    def stop(self):
        """Stop the engine of the car!"""
        self.engine = "Stopping"

    def honk(self):
        """
        Use
        "The"
        ""Horn""
        """
        print("Honking...")
        print("Honk Honk!")

    def __str__(self):
        """
        example of a longer multiline-docstring,
        everything will be printed on a single line
        """
        return self.number_plate
```
## Output:
```console
# ex/car.py
## ex/car.py
| def | doc-str |
| --- | --- |
|     __init__(self) | no docstring |
|     start(self) | starts the engine of the car |
|     stop(self) | stop the engine of the car! |
|     honk(self) | use "the" ""horn"" |
|     __str__(self) | example of a longer multiline-docstring, everything will be printed on a single line |
```