### PR TITLE
Fixed issue with function definitions, and removed lowercase

### DIFF
--- a/ex/car.py
+++ b/ex/car.py
@@ -16,9 +16,11 @@ class car:
     def honk(self):
         """
         Use
-        "The"
-        ""Horn""
+        "the"
+        ""horn""
         """
+        # def
+        test = "def"
         print("Honking...")
         print("Honk Honk!")
 

--- a/inkpot/filter.py
+++ b/inkpot/filter.py
@@ -12,7 +12,7 @@ def filter_file(file_path):
     with open(file_path, "r") as file:
         for cnt, line in enumerate(file):
             # print("Line {}: {}".format(cnt, line))
-            if "def" in line:
+            if line.lstrip().find("def ") == 0:
                 func = line.replace("def ", "")
                 func = func.replace("\n", "")
                 func = func.replace(":", "")
@@ -37,7 +37,7 @@ def filter_file(file_path):
                 doc += line.strip() + " "
 
                 if doc_open and doc_close:
-                    table[last_func] = doc.strip().strip(doc_token).strip().lower()
+                    table[last_func] = doc.strip().strip(doc_token).strip()
                     doc_open = None
                     doc_close = None
                     doc = ""


### PR DESCRIPTION
There was an issue when extracting function definitions in the previous version, for example you could write something like:
```python
#def 
test = "def"
```
Both the comment and the string declaration would be interpreted as functions, but that is no longer the case.