### PR TITLE
Added file-node support (classes, modules etc..) and better formatting for output. 

### DIFF
--- a/ex/car.py
+++ b/ex/car.py
@@ -19,6 +19,8 @@ class car:
         "the"
         ""horn""
         """
+        def nested_test():
+            pass
         # def
         test = "def"
         print("Honking...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pluggy==0.13.1
 py==1.10.0
 pyparsing==2.4.7
 pytest==6.2.4
+tabulate=0.8.9
 toml==0.10.2


### PR DESCRIPTION
I found a Python base module called "ast". It parses a source file and checks for specified nodes (class, module etc..). I also changed the file-output to a markdown table format which looks much better in my opinion.
```bash
python3 -m inkpot ex/car.py > car_test.md
```
### Output:
[car_test.md](https://github.com/AxelGard/inkpot/files/6764675/car_test.md)

