### PR TITLE
Added support for coroutines declared with async/await syntax

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -27,7 +27,7 @@
 >> `nested function inside honk` 
 >>
 > **def \_\_str\_\_(self)** \
-> `Eexample of a longer multiline-docstring,` \
+> `Example of a longer multiline-docstring,` \
 `everything will still be formatted correctly` 
 >
 > **@staticmethod \
@@ -35,6 +35,9 @@
 def funcname(param1: str, param2: int)** \
 > `The docstring to the static method` 
 >
+**async def async_def_test(a, b, c)** \
+`Testing coroutines declared with async syntax` 
+
 **def no_class_def_test()** \
 `None` 
 

--- a/inkpot/file.py
+++ b/inkpot/file.py
@@ -69,6 +69,9 @@ class File:
             self.ouput(node, header, docstring)
             self.generic_visit(node)
 
+        def visit_AsyncFunctionDef(self, node):
+            self.visit_FunctionDef(node)
+
     def __init__(self, path: str):
         """ constructor """
         self._path = path

--- a/tests/.ex/car.py
+++ b/tests/.ex/car.py
@@ -1,3 +1,6 @@
+import asyncio
+
+
 class Car:
     """The Car class"""
     class Engine:
@@ -36,7 +39,7 @@ class Car:
 
     def __str__(self):
         """
-        Eexample of a longer multiline-docstring,
+        Example of a longer multiline-docstring,
         everything will still be formatted correctly
         """
         return self.number_plate
@@ -48,6 +51,15 @@ class Car:
         The docstring to the static method
         """
         print(param1, param2)
+
+
+async def async_def_test(a, b, c):
+    """
+    Testing coroutines declared with async syntax
+    """
+    print("hello")
+    await asyncio.sleep(1)
+    print("world")
 
 
 def no_class_def_test():


### PR DESCRIPTION
Added support for coroutines declared with async/await syntax.
```python
async def async_def_test(a, b, c):
    """
    Testing coroutines declared with async syntax
    """
    print("hello")
    await asyncio.sleep(1)
    print("world")
```